### PR TITLE
Install flow tool for static analysis 

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,14 @@
+[ignore]
+
+[include]
+
+[libs]
+
+[lints]
+untyped-type-import=error
+internal-type=error
+deprecated-type-bool=error
+
+[options]
+
+[strict]


### PR DESCRIPTION
Static analysis tool `Flow `is installed in the codebase through the command `npm install --save-dev flow-bin`. To configure the `Node.js` codebase to use the tool, a `Flow ` script is added in `package.json`. The tool was then initialized through the command ` npm run flow init`. This created a `.flowconfig` file that defines the tool's configuration to work correctly within the codebase. Additionally, the command `npm run flow` was deployed to launch the Flow server and confirm that no errors were found in the codebase.

The following screenshot of the terminal shows the output of running` npm run flow init` and executing `npm run flow`.

<img width="894" alt="Screenshot 2024-10-23 at 7 57 33 PM" src="https://github.com/user-attachments/assets/34184d81-e17e-430c-a2fe-b04e86d8a8bc">
