### PR TITLE
Install stryker mutation tool for dynamic analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,5 @@ test.sh
 
 .docker/**
 !**/.gitkeep
+# stryker temp files
+.stryker-tmp

--- a/stryker.config.mjs
+++ b/stryker.config.mjs
@@ -1,0 +1,13 @@
+// @ts-check
+/** @type {import('@stryker-mutator/api/core').PartialStrykerOptions} */
+const config = {
+  _comment:
+    "This config was generated using 'stryker init'. Please take a look at: https://stryker-mutator.io/docs/stryker-js/configuration/ for more information.",
+  packageManager: "npm",
+  reporters: ["html", "clear-text", "progress"],
+  testRunner: "mocha",
+  testRunner_comment:
+    "Take a look at https://stryker-mutator.io/docs/stryker-js/mocha-runner for information about the mocha plugin.",
+  coverageAnalysis: "perTest",
+};
+export default config;


### PR DESCRIPTION
Stryker Mutator, a mutation testing tool, is integrated into the NodeBB codebase through installation using the command `npm init stryker`. This initializes the tool's configuration by creating a `stryker.config.mjs` file. During setup, key parameters were selected, including Mocha as the test runner, `tsc -b` as the build command, and `html, clear-text, progress` as reporters. The package manager was set to `npm`, and the configuration file was written in JavaScript. Once configured, Stryker was executed using `npx stryker run`, and mutation tests were successfully conducted to assess the robustness of the test suite.

<img width="906" alt="Screenshot 2024-10-24 at 3 14 00 PM" src="https://github.com/user-attachments/assets/b55016cd-3a19-47b0-a6cf-411cb6ff20b7">

![Image 24-10-2024 at 3 13 PM](https://github.com/user-attachments/assets/38deb601-a491-4324-9c7e-1495deceabe9)

![Image 24-10-2024 at 3 33 PM](https://github.com/user-attachments/assets/0bf5ae63-0822-4ba1-b20c-ca5f4ed89025)
