### PR TITLE
Add basic translator service

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,46 @@
+{
+    // JSHint Configuration File
+    // Taken from https://github.com/jshint/jshint/blob/main/examples/.jshintrc
+
+    // Enforcing
+    "bitwise"       : true,     // true: Prohibit bitwise operators (&, |, ^, etc.)
+    "camelcase"     : false,    // true: Identifiers must be in camelCase
+    "curly"         : true,     // true: Require {} for every new block or scope
+    "eqeqeq"        : true,     // true: Require triple equals (===) for comparison
+    "forin"         : true,     // true: Require filtering for..in loops with obj.hasOwnProperty()
+    "freeze"        : true,     // true: prohibits overwriting prototypes of native objects such as Array, Date etc.
+    "immed"         : false,    // true: Require immediate invocations to be wrapped in parens e.g. `(function () { } ());`
+    "latedef"       : false,    // true: Require variables/functions to be defined before being used
+    "newcap"        : false,    // true: Require capitalization of all constructor functions e.g. `new F()`
+    "noarg"         : true,     // true: Prohibit use of `arguments.caller` and `arguments.callee`
+    "noempty"       : true,     // true: Prohibit use of empty blocks
+    "nonbsp"        : true,     // true: Prohibit "non-breaking whitespace" characters.
+    "nonew"         : false,    // true: Prohibit use of constructors for side-effects (without assignment)
+    "plusplus"      : false,    // true: Prohibit use of `++` and `--`
+    "undef"         : true,     // true: Require all non-global variables to be declared (prevents global leaks)
+    "strict"        : true,     // true: Requires all functions run in ES5 Strict Mode
+
+    // Relaxing
+    "asi"           : false,     // true: Tolerate Automatic Semicolon Insertion (no semicolons)
+    "boss"          : false,     // true: Tolerate assignments where comparisons would be expected
+    "debug"         : false,     // true: Allow debugger statements e.g. browser breakpoints.
+    "eqnull"        : false,     // true: Tolerate use of `== null`
+    "evil"          : false,     // true: Tolerate use of `eval` and `new Function()`
+    "expr"          : false,     // true: Tolerate `ExpressionStatement` as Programs
+    "funcscope"     : false,     // true: Tolerate defining variables inside control statements
+    "globalstrict"  : false,     // true: Allow global "use strict" (also enables 'strict')
+    "iterator"      : false,     // true: Tolerate using the `__iterator__` property
+    "lastsemic"     : false,     // true: Tolerate omitting a semicolon for the last statement of a 1-line block
+    "laxbreak"      : false,     // true: Tolerate possibly unsafe line breakings
+    "laxcomma"      : false,     // true: Tolerate comma-first style coding
+    "loopfunc"      : false,     // true: Tolerate functions being defined in loops
+    "multistr"      : false,     // true: Tolerate multi-line strings
+    "noyield"       : false,     // true: Tolerate generator functions with no yield statement in them.
+    "notypeof"      : false,     // true: Tolerate invalid typeof operator values
+    "proto"         : false,     // true: Tolerate using the `__proto__` property
+    "scripturl"     : false,     // true: Tolerate script-targeted URLs
+    "shadow"        : false,     // true: Allows re-define variables later in code e.g. `var x=1; x=2;`
+    "sub"           : false,     // true: Tolerate using `[]` notation when it can still be expressed in dot notation
+    "supernew"      : false,     // true: Tolerate `new function () { ... };` and `new Object;`
+    "validthis"     : false     // true: Tolerate using this in a non-constructor function
+}

--- a/public/src/client/topic.js
+++ b/public/src/client/topic.js
@@ -71,11 +71,26 @@ define('forum/topic', [
 		handleThumbs();
 
 		$(window).on('scroll', utils.debounce(updateTopicTitle, 250));
+		configurePostToggle();
 
 		handleTopicSearch();
 
 		hooks.fire('action:topic.loaded', ajaxify.data);
 	};
+
+	function configurePostToggle() {
+        $(".topic").on("click", ".view-translated-btn", function () {
+            // Toggle the visibility of the next .translated-content div
+            $(this).closest('.sensitive-content-message').next('.translated-content').toggle();
+            // Optionally, change the button text based on visibility
+            var isVisible = $(this).closest('.sensitive-content-message').next('.translated-content').is(':visible');
+            if (isVisible) {
+                $(this).text('Hide the translated message.');
+            } else {
+                $(this).text('Click here to view the translated message.');
+            }
+        });
+    }
 
 	function handleTopicSearch() {
 		require(['mousetrap'], (mousetrap) => {

--- a/src/posts/create.js
+++ b/src/posts/create.js
@@ -10,6 +10,7 @@ const topics = require('../topics');
 const categories = require('../categories');
 const groups = require('../groups');
 const privileges = require('../privileges');
+const translate = require('../translate');
 
 module.exports = function (Posts) {
 	Posts.create = async function (data) {
@@ -19,6 +20,7 @@ module.exports = function (Posts) {
 		const content = data.content.toString();
 		const timestamp = data.timestamp || Date.now();
 		const isMain = data.isMain || false;
+		const [isEnglish, translatedContent] = await translate.translate(data)
 
 		if (!uid && parseInt(uid, 10) !== 0) {
 			throw new Error('[[error:invalid-uid]]');
@@ -35,6 +37,8 @@ module.exports = function (Posts) {
 			tid: tid,
 			content: content,
 			timestamp: timestamp,
+			translatedContent: translatedContent,
+			isEnglish: isEnglish,
 		};
 
 		if (data.toPid) {

--- a/src/posts/data.js
+++ b/src/posts/data.js
@@ -67,5 +67,7 @@ function modifyPost(post, fields) {
 		if (post.hasOwnProperty('edited')) {
 			post.editedISO = post.edited !== 0 ? utils.toISOString(post.edited) : '';
 		}
+		// Mark post as "English" if decided by translator service or if it has no info
+		post.isEnglish = post.isEnglish == "true" || post.isEnglish === undefined;
 	}
 }

--- a/src/translate/index.js
+++ b/src/translate/index.js
@@ -1,0 +1,11 @@
+var request = require('request');
+
+const translatorApi = module.exports;
+
+translatorApi.translate = async function (postData) {
+    // Edit the translator URL below
+    const TRANSLATOR_API = "https://nodebb-f24-translator.azurewebsites.net/"
+    const response = await fetch(TRANSLATOR_API+'/?content='+postData.content);
+    const data = await response.json();
+    return [data["is_english"], data["translated_content"]]
+}


### PR DESCRIPTION
This adds the basic translator service that returns hard-coded dummy translations. The deployment of the Python app is at [https://github.com/mohamed-elzeni/translator-service](https://github.com/mohamed-elzeni/translator-service).

This has been tested by the listing and testing suite. In addition to testing the UI on the deployed NodeBB instance.